### PR TITLE
add copy target for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,12 @@ OBJ			= $(FILES:%.c=%.o)
 
 all: $(NAME)
 
+copy:
+	cp -f libc-funcs/*.c .
+	cp -f additional-funcs/*.c .
+	cp -f bonus-funcs/*.c .
+	cp -f personal-funcs/*.c .
+
 # This won't run if the .o files don't exist or are not modified
 $(NAME): $(OBJ)
 	ar rcs $(NAME) $(OBJ)


### PR DESCRIPTION
As stated in Readme.md, all the *.c files need to reside in the top directory for make to succeed in compiling. I added a make target so the copying does not have to be done manually.
