### PR TITLE
Makefile all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ OBJ			= $(FILES:%.c=%.o)
 
 all: copy $(NAME) clean
 
+# This will copy all c files to the top directory
 copy:
 	cp -f libc-funcs/*.c .
 	cp -f additional-funcs/*.c .

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ FILES		= ft_memset.c \
 				ft_capitalize.c
 OBJ			= $(FILES:%.c=%.o)
 
-all: $(NAME)
+all: copy $(NAME) clean
 
 copy:
 	cp -f libc-funcs/*.c .

--- a/Makefile-sample
+++ b/Makefile-sample
@@ -77,7 +77,14 @@ CFLAGS		= -Wall -Werror -Wextra -I. -c
 				ft_capitalize.c
 OBJ			= $(FILES:%.c=%.o)
 
-all: $(NAME)
+all: copy $(NAME) clean
+
+# This will copy all c files to the top directory
+copy:
+	cp -f libc-funcs/*.c .
+	cp -f additional-funcs/*.c .
+	cp -f bonus-funcs/*.c .
+	cp -f personal-funcs/*.c .
 
 # This won't run if the .o files don't exist or are not modified
 $(NAME): $(OBJ)


### PR DESCRIPTION
This merge extends the 'all' target to include the 'copy' and 'clean' steps and updates Makefile-sample to do the same.
